### PR TITLE
Notify message to typetalk in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,11 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
+
+orbs:
+  typetalk: ikikko/typetalk@0.0.1
+
 jobs:
   build:
     docker:
@@ -33,3 +37,6 @@ jobs:
 
       - store_test_results:
           path: reports
+
+      - typetalk/notify:
+          topic-id: "54145"


### PR DESCRIPTION
By using a custom orb which I created https://circleci.com/orbs/registry/orb/ikikko/typetalk

# What I did
1. Create and publish [the custom Typetalk orb](https://circleci.com/orbs/registry/orb/ikikko/typetalk)
2. Update a `.circleci/config.yml` in this repository ( changed in this PR )
3. Change some settings in CircleCI
    * [Orb Security Settings](https://circleci.com/gh/organizations/nulab/settings#security) : `Allow Uncertified Orbs` to `Yes`
    * [Environment Variables](https://circleci.com/gh/nulab/backlog-bulk-issue-registration-gas/edit#env-vars) : Add `TYPETALK_TOKEN`

( I want to move that orb from my personal namespace to nulab official. But at this time, I use the orb in 
 my namespace. )

# Image
![image](https://user-images.githubusercontent.com/26503/56908364-21df9f00-6ae1-11e9-9d92-4ad2a25599db.png)