### PR TITLE
STEP2 登録処理の定期実行用関数を追加

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,17 @@ global.getConfig = function () {
   return service.getUserProperties()
 }
 
+global.run_cron = function () {
+  let config = global.getConfig()
+  let property = {
+    "space": config.space,
+    "domain": config.domain,
+    "projectKey": config.projectKey,
+    "apiKey": config.apiKey
+  }
+  service.run(property)
+}
+
 global.getMessage = function (key: string) {
   return service.getMessage(key)
 }


### PR DESCRIPTION
## PR内容
GASのトリガーで定期的に登録処理実行可能にするための関数を追加しました。
元々あったrun_dではspace情報を入力しないといけなかったため、STEP1で
入力されている情報をそのまま使って登録処理行うようにしています。
（STEP１でスペース情報他を登録していることが前提）

## 設定手順
1. STEP１でスペース情報他を入力
3. Google Spreadのプロジェクトでトリガーを設定
